### PR TITLE
Add basic stubs for GLFW input and Vulkan functions

### DIFF
--- a/glfw/input.go
+++ b/glfw/input.go
@@ -1,5 +1,7 @@
 package glfw
 
+import "image"
+
 // Joystick corresponds to a joystick.
 type Joystick int
 
@@ -294,3 +296,84 @@ const (
 	CursorDisabled int = 0x00034003
 	CursorCaptured int = 0x00034004
 )
+
+// TODO: implement these input functions
+
+// GetInputMode returns the value of an input option of the window.
+func (w *Window) GetInputMode(mode InputMode) int {
+	return 0
+}
+
+// SetInputMode sets an input option for the window.
+func (w *Window) SetInputMode(mode InputMode, value int) {}
+
+// RawMouseMotionSupported returns whether raw mouse motion is supported on the
+// current system. This status does not change after GLFW has been initialized
+// so you only need to check this once. If you attempt to enable raw motion on
+// a system that does not support it, PlatformError will be emitted.
+//
+// Raw mouse motion is closer to the actual motion of the mouse across a
+// surface. It is not affected by the scaling and acceleration applied to the
+// motion of the desktop cursor. That processing is suitable for a cursor while
+// raw motion is better for controlling for example a 3D camera. Because of
+// this, raw mouse motion is only provided when the cursor is disabled.
+//
+// This function must only be called from the main thread.
+func RawMouseMotionSupported() bool {
+	return true
+}
+
+// Cursor represents a cursor.
+type Cursor struct{}
+
+// GetCursorPos returns the last reported position of the cursor.
+//
+// If the cursor is disabled (with CursorDisabled) then the cursor position is
+// unbounded and limited only by the minimum and maximum values of a double.
+//
+// The coordinate can be converted to their integer equivalents with the floor
+// function. Casting directly to an integer type works for positive coordinates,
+// but fails for negative ones.
+func (w *Window) GetCursorPos() (x, y float64) {
+	return
+}
+
+// SetCursorPos sets the position of the cursor. The specified window must
+// be focused. If the window does not have focus when this function is called,
+// it fails silently.
+//
+// If the cursor is disabled (with CursorDisabled) then the cursor position is
+// unbounded and limited only by the minimum and maximum values of a double.
+func (w *Window) SetCursorPos(xpos, ypos float64) {}
+
+// CreateCursor creates a new custom cursor image that can be set for a window with SetCursor.
+// The cursor can be destroyed with Destroy. Any remaining cursors are destroyed by Terminate.
+//
+// The image is ideally provided in the form of *image.NRGBA.
+// The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
+// bits per channel with the red channel first. They are arranged canonically
+// as packed sequential rows, starting from the top-left corner. If the image
+// type is not *image.NRGBA, it will be converted to it.
+//
+// The cursor hotspot is specified in pixels, relative to the upper-left corner of the cursor image.
+// Like all other coordinate systems in GLFW, the X-axis points to the right and the Y-axis points down.
+func CreateCursor(img image.Image, xhot, yhot int) *Cursor {
+	return &Cursor{}
+}
+
+// CreateStandardCursor returns a cursor with a standard shape,
+// that can be set for a window with SetCursor.
+func CreateStandardCursor(shape StandardCursor) *Cursor {
+	return &Cursor{}
+}
+
+// Destroy destroys a cursor previously created with CreateCursor.
+// Any remaining cursors will be destroyed by Terminate.
+func (c *Cursor) Destroy() {}
+
+// SetCursor sets the cursor image to be used when the cursor is over the client area
+// of the specified window. The set cursor will only be visible when the cursor mode of the
+// window is CursorNormal.
+//
+// On some platforms, the set cursor may not be visible unless the window also has input focus.
+func (w *Window) SetCursor(c *Cursor) {}

--- a/glfw/vulkan.go
+++ b/glfw/vulkan.go
@@ -1,0 +1,42 @@
+package glfw
+
+import (
+	"unsafe"
+)
+
+// VulkanSupported reports whether the Vulkan loader has been found. This check is performed by Init.
+//
+// The availability of a Vulkan loader does not by itself guarantee that window surface creation or
+// even device creation is possible. Call GetRequiredInstanceExtensions to check whether the
+// extensions necessary for Vulkan surface creation are available and GetPhysicalDevicePresentationSupport
+// to check whether a queue family of a physical device supports image presentation.
+func VulkanSupported() bool {
+	return true
+}
+
+// GetVulkanGetInstanceProcAddress returns the function pointer used to find Vulkan core or
+// extension functions. The return value of this function can be passed to the Vulkan library.
+//
+// Note that this function does not work the same way as the glfwGetInstanceProcAddress.
+func GetVulkanGetInstanceProcAddress() unsafe.Pointer {
+	return nil
+}
+
+// GetRequiredInstanceExtensions returns a slice of Vulkan instance extension names required
+// by GLFW for creating Vulkan surfaces for GLFW windows. If successful, the list will always
+// contain VK_KHR_surface, so if you don't require any additional extensions you can pass this list
+// directly to the VkInstanceCreateInfo struct.
+//
+// If Vulkan is not available on the machine, this function returns nil. Call
+// VulkanSupported to check whether Vulkan is available.
+//
+// If Vulkan is available but no set of extensions allowing window surface creation was found, this
+// function returns nil. You may still use Vulkan for off-screen rendering and compute work.
+func (window *Window) GetRequiredInstanceExtensions() []string {
+	return nil
+}
+
+// CreateWindowSurface creates a Vulkan surface for this window.
+func (window *Window) CreateWindowSurface(instance interface{}, allocCallbacks unsafe.Pointer) (surface uintptr, err error) {
+	return
+}


### PR DESCRIPTION
This PR does not actually implement any of these functions, but it adds the signatures so that code that used to use the old glfw can at least compile with mado. This makes Cogent Core build with mado. In terms of implementing these functions, do you want me to put the necessary C code in the app directory or the glfw directory? Do you want the glfw directory to only be wrappers on the app directory with all of the logic in there, or are you okay with putting logic in the glfw directory itself? 